### PR TITLE
Low-Light Vision

### DIFF
--- a/src/helpers/libWrapper.ts
+++ b/src/helpers/libWrapper.ts
@@ -1,0 +1,44 @@
+interface Objects
+{
+    KeyboardManager: typeof KeyboardManager
+    PerceptionManager: typeof PerceptionManager
+    PointSource: typeof PointSource
+    Token: typeof Token
+}
+
+type Lookup<T, Path> =
+    (Path extends `${infer Key}.${infer RestOfPath}` ?
+        (Key extends keyof T ?
+            Lookup<T[Key], RestOfPath> :
+            never) :
+        (Path extends keyof T ?
+            AddContextIfFunction<T[Path], T> :
+            never))
+
+type AddContextIfFunction<Value, Context> =
+    (Value extends (...args: any) => any ?
+        WithThisParameter<Value, Context> :
+        Value)
+
+type WithWrapper<Function> =
+    (Function extends (this: infer This, ...args: infer Args) => infer Return ?
+        (this: This, wrapped: (...args: Args) => Return, ...args: Args) => Return :
+        unknown)
+
+interface LibWrapper
+{
+    register<P extends string>(module: string, target: P, fn: WithWrapper<Lookup<Objects, P>>, mode: 'MIXED' | 'WRAPPER'): void
+    register<P extends string>(module: string, target: P, fn: Lookup<Objects, P>, mode: 'OVERRIDE'): void
+    register<F>(module: string, target: string, fn: WithWrapper<F>, mode: 'MIXED' | 'WRAPPER'): void
+    register<F>(module: string, target: string, fn: F, mode: 'OVERRIDE'): void
+}
+
+export { }
+
+declare global
+{
+    type WithThisParameter<Fn extends (...args: any) => any, This> =
+        (this: This, ...args: Parameters<Fn>) => ReturnType<Fn>
+
+    const libWrapper: LibWrapper
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import StatusEffectConfig from "./effects/StatusEffectConfig"
 import StatusEffectNotifier from './effects/StatusEffectNotifier'
 import StatusEffectScheduler from './effects/StatusEffectScheduler'
 import MomentChangedEmitter from "./effects/MomentChangedEmitter"
+import './rendering/LowLightVision'
 
 Hooks.once('init', function()
 {
@@ -23,13 +24,15 @@ Hooks.once('init', function()
 
     CONFIG.ActiveEffect.documentClass = StatusEffect
     CONFIG.ActiveEffect.sheetClass = StatusEffectConfig
+
+    wor.rendering.LowLightVision.init()
 })
 
 Hooks.once('ready', function()
 {
     MomentChangedEmitter.init()
-    StatusEffectScheduler.init()
     StatusEffectNotifier.init()
+    StatusEffectScheduler.init()
 })
 
 if (DEBUG)

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,14 +18,14 @@ import StatusEffectScheduler from './effects/StatusEffectScheduler'
 import MomentChangedEmitter from "./effects/MomentChangedEmitter"
 import './rendering/LowLightVision'
 
+wor.rendering.LowLightVision.registerHooks()
+
 Hooks.once('init', function()
 {
     CONFIG.time.roundTime = 6
 
     CONFIG.ActiveEffect.documentClass = StatusEffect
     CONFIG.ActiveEffect.sheetClass = StatusEffectConfig
-
-    wor.rendering.LowLightVision.init()
 })
 
 Hooks.once('ready', function()

--- a/src/rendering/LowLightVision.ts
+++ b/src/rendering/LowLightVision.ts
@@ -1,0 +1,91 @@
+import { expect } from "../helpers/assertions"
+
+namespace wor.rendering.LowLightVision
+{
+    let lowLightVision = false
+
+    export function init()
+    {
+        function useLowLightVision()
+        {
+            expect(canvas?.tokens)
+
+            let any = false
+
+            for (const token of canvas.tokens.placeables)
+            {
+                if (!token._isVisionSource())
+                    continue
+
+                if (token.name != 'Maragna')
+                    return false
+
+                any = true
+            }
+
+            return any
+        }
+
+        function patchPerceptionManager(this: PerceptionManager)
+        {
+            const original = this.schedule
+
+            this.schedule = function(options)
+            {
+                expect(canvas?.tokens)
+
+                var llv = useLowLightVision()
+                if (llv != lowLightVision)
+                {
+                    lowLightVision = llv
+
+                    options ??= {}
+                    options.lighting ??= {}
+                    options.lighting.initialize = true
+                }
+
+                original.call(this, options)
+            }
+        }
+
+        patchPerceptionManager.call(canvas!.perception)
+
+        function patchPointSource(this: PointSource)
+        {
+            const original = this.initialize
+
+            this.initialize = function(data)
+            {
+                if (this.sourceType == 'light' && lowLightVision)
+                {
+                    data ??= {}
+
+                    const dim = data.dim ?? 0
+                    const bright = data.bright ?? 0
+
+                    if (dim > bright)
+                    {
+                        data.dim = 2 * dim - bright
+                        data.bright = dim
+                    }
+                }
+
+                return original.call(this, data)
+            }
+        }
+        patchPointSource.call(PointSource.prototype)
+    }
+}
+
+/* export interop */
+type ThisModule = typeof wor.rendering.LowLightVision
+
+declare global
+{
+    namespace wor.rendering
+    {
+        export const LowLightVision: ThisModule
+    }
+}
+
+mergeObject(globalThis, { wor })

--- a/src/rendering/LowLightVision.ts
+++ b/src/rendering/LowLightVision.ts
@@ -1,79 +1,87 @@
 import { expect } from "../helpers/assertions"
 
+declare global
+{
+    interface PointSource
+    {
+        sourceType: 'light' | 'sight'
+    }
+}
+
 namespace wor.rendering.LowLightVision
 {
-    let lowLightVision = false
+    // let lowLightVision = false
 
     export function init()
     {
-        function useLowLightVision()
-        {
-            expect(canvas?.tokens)
+        // function useLowLightVision()
+        // {
+        //     expect(canvas?.tokens)
 
-            let any = false
+        //     let any = false
 
-            for (const token of canvas.tokens.placeables)
-            {
-                if (!token._isVisionSource())
-                    continue
+        //     for (const token of canvas.tokens.placeables)
+        //     {
+        //         if (!token._isVisionSource())
+        //             continue
 
-                if (token.name != 'Maragna')
-                    return false
+        //         if (token.name != 'Maragna')
+        //             return false
 
-                any = true
-            }
+        //         any = true
+        //     }
 
-            return any
-        }
+        //     return any
+        // }
 
-        function patchPerceptionManager(this: PerceptionManager)
-        {
-            const original = this.schedule
+        // function patchPerceptionManager(this: PerceptionManager)
+        // {
+        //     const original = this.schedule
 
-            this.schedule = function(options)
-            {
-                expect(canvas?.tokens)
+        //     this.schedule = function(options)
+        //     {
+        //         expect(canvas?.tokens)
 
-                var llv = useLowLightVision()
-                if (llv != lowLightVision)
-                {
-                    lowLightVision = llv
+        //         var llv = useLowLightVision()
+        //         if (llv != lowLightVision)
+        //         {
+        //             lowLightVision = llv
 
-                    options ??= {}
-                    options.lighting ??= {}
-                    options.lighting.initialize = true
-                }
+        //             options ??= {}
+        //             options.lighting ??= {}
+        //             options.lighting.initialize = true
+        //         }
 
-                original.call(this, options)
-            }
-        }
+        //         original.call(this, options)
+        //     }
+        // }
 
-        patchPerceptionManager.call(canvas!.perception)
+        // patchPerceptionManager.call(canvas!.perception)
 
-        function patchPointSource(this: PointSource)
-        {
-            const original = this.initialize
+        // function patchPointSource(this: PointSource)
+        // {
+        //     const original = this.initialize
 
-            this.initialize = function(data)
-            {
-                if (this.sourceType == 'light' && lowLightVision)
-                {
-                    data ??= {}
+        //     this.initialize = function(data)
+        //     {
+        //         if (this.sourceType == 'light' && lowLightVision)
+        //         {
+        //             data ??= {}
 
-                    const dim = data.dim ?? 0
-                    const bright = data.bright ?? 0
+        //             const dim = data.dim ?? 0
+        //             const bright = data.bright ?? 0
 
-                    if (dim > bright)
-                    {
-                        data.dim = 2 * dim - bright
-                        data.bright = dim
-                    }
-                }
+        //             if (dim > bright)
+        //             {
+        //                 data.dim = 2 * dim - bright
+        //                 data.bright = dim
+        //             }
+        //         }
 
-                return original.call(this, data)
-            }
-        }
-        patchPointSource.call(PointSource.prototype)
+        //         return original.call(this, data)
+        //     }
+        // }
+        // patchPointSource.call(PointSource.prototype)
     }
 }
 

--- a/src/rendering/LowLightVision.ts
+++ b/src/rendering/LowLightVision.ts
@@ -3,11 +3,13 @@ import { requireElement } from "../helpers/require-element"
 
 declare global
 {
+    // Add missing type definitions:
     interface PointSource
     {
         sourceType: 'light' | 'sight'
     }
 
+    // Add our custom token property:
     interface FlagConfig
     {
         Token: {
@@ -18,6 +20,7 @@ declare global
     }
 }
 
+// A surprise tool that will help us later:
 function omitThisParameter<Function>(fn: Function): OmitThisParameter<Function>
 {
     return fn as OmitThisParameter<Function>
@@ -25,7 +28,10 @@ function omitThisParameter<Function>(fn: Function): OmitThisParameter<Function>
 
 namespace wor.rendering
 {
+    /** Whether the canvas is currently being rendered with LLV. */
     let active: boolean = false
+
+    /** GM override for LLV. */
     let override: boolean | undefined
 
     export const LowLightVision = new class
@@ -45,7 +51,9 @@ namespace wor.rendering
         set active(value: boolean | undefined)
         {
             override = value
-            unwrap(canvas).perception.schedule({
+
+            // Trigger a rerender:
+            canvas?.perception.schedule({
                 lighting: { refresh: true },
                 sight: { refresh: true }
             })
@@ -54,6 +62,8 @@ namespace wor.rendering
 
     function onInit()
     {
+        // This method occurs in-between clicking a token and rendering the lighting. It’s the
+        // perfect hook to check for LLV.
         libWrapper.register('wor', 'PerceptionManager.prototype.schedule', function(wrapped, options = {})
         {
             const value = override ?? isEnabledForCurrentVisionSource()
@@ -63,20 +73,22 @@ namespace wor.rendering
                 setProperty(options, 'lighting.initialize', true)
                 setProperty(options, 'sight.initialize', true)
             }
-
             return wrapped(options)
         }, 'WRAPPER')
 
+        // Hook into light source updates.
         libWrapper.register('wor', 'PointSource.prototype.initialize', function(wrapped, data = {})
         {
             if (this.sourceType === 'light')
+            {
                 applyToLightData(data)
-
+            }
             return wrapped(data)
         }, 'WRAPPER')
 
         type F = WithThisParameter<Token['_onUpdate'], Token>
 
+        // Trick Foundry into rerendering when we edit a token’s vision.
         libWrapper.register<F>('wor', 'Token.prototype._onUpdate', function(wrapped, data = {}, options, userId)
         {
             if (data.flags?.wor?.lowLightVision !== undefined)
@@ -93,6 +105,7 @@ namespace wor.rendering
         {
             type F = WithThisParameter<KeyboardManager['_handleKeys'], KeyboardManager>
 
+            // Let the GM preview what LLV looks like.
             libWrapper.register<F>('wor', 'KeyboardManager.prototype._handleKeys', function(wrapped, event, key, up)
             {
                 if (key == 'l')
@@ -106,6 +119,12 @@ namespace wor.rendering
         }
     }
 
+    /**
+     * Whether the current source of vision has LLV.
+     *
+     * This method returns `false` if there are no vision sources. If there are multiple vision
+     * sources, this method only returns `true` if they _all_ have LLV.
+     */
     function isEnabledForCurrentVisionSource(): boolean
     {
         expect(canvas && canvas.tokens)
@@ -122,16 +141,19 @@ namespace wor.rendering
         return any
     }
 
+    /** Whether the given token is (currently) a source of vision. */
     const isVisionSource = omitThisParameter(function(this: Token, token: Token)
     {
         return token._isVisionSource()
     })
 
+    /** Whether the given token has LLV. */
     function isEnabledFor(token: Token): boolean
     {
         return !!token.data.flags.wor?.lowLightVision
     }
 
+    /** Extend the radii of the specified light. */
     function applyToLightData(data: { dim?: number, bright?: number }): void
     {
         if (active)
@@ -146,6 +168,7 @@ namespace wor.rendering
         }
     }
 
+    /** Add a LLV checkbox to token configuration. */
     function onRenderTokenConfig(config: TokenConfig, html: JQuery)
     {
         const dimSightField = requireElement(html, 'dimSight', HTMLInputElement)

--- a/system.json
+++ b/system.json
@@ -7,6 +7,9 @@
     "compatibleCoreVersion": "0.8.9",
     "dependencies": [
         {
+            "name": "lib-wrapper"
+        },
+        {
             "name": "token-auras"
         }
     ],


### PR DESCRIPTION
This pull request implements “low-light vision” as per the Pathfinder 1e rules. It’s available as an option on the token configuration dialog. Furthermore, a GM can preview their scene with low-light vision by holding the L key.