### PR TITLE
Improved UX for status effects

### DIFF
--- a/src/characters/CharacterSheet/index.ts
+++ b/src/characters/CharacterSheet/index.ts
@@ -117,7 +117,7 @@ export class CharacterSheet extends ActorSheet
                 return showEditorFor(getClickedEffect())
 
             case 'wor-delete-effect':
-                return getClickedEffect().delete()
+                return handleDeleteEffect()
 
             default:
                 throw new Error(`Unhandled case: ${dataset.action}`)
@@ -132,6 +132,25 @@ export class CharacterSheet extends ActorSheet
                 parent: actor
             })
             showEditorFor(unwrap(created))
+        }
+
+        function handleDeleteEffect()
+        {
+            const effect = getClickedEffect()
+            if (effect.getFlag('wor', 'expired'))
+            {
+                effect.delete()
+            }
+            else
+            {
+                const opts: Partial<Dialog.Options> = {
+                    top: unwrap(sheet.position.top) + 40,
+                    left: unwrap(sheet.position.left) + 10
+                }
+                // @ts-expect-error
+                const opts2: Dialog.Options = opts
+                effect.deleteDialog(opts2)
+            }
         }
 
         function getClickedEffect(): StatusEffect

--- a/src/characters/CharacterSheet/index.ts
+++ b/src/characters/CharacterSheet/index.ts
@@ -143,7 +143,10 @@ export class CharacterSheet extends ActorSheet
 
         function showEditorFor(effect: StatusEffect)
         {
-            effect.sheet.render(true)
+            effect.sheet.render(true, {
+                top: unwrap(sheet.position.top) + 40,
+                left: unwrap(sheet.position.left) + 10
+            })
         }
     }
 

--- a/src/characters/CharacterSheet/template.hbs
+++ b/src/characters/CharacterSheet/template.hbs
@@ -50,9 +50,11 @@
     <section class='wor-section wor-effects'>
         <h3 class='wor-section-header'>
             <span>Status Effects</span>
+            {{#if editable}}
             <a data-action='wor-add-effect' title='Add'>
                 <i class='fas fa-plus'></i>
             </a>
+            {{/if}}
         </h3>
         {{#if effects}}
         <ul class='wor-list'>
@@ -61,12 +63,14 @@
                 <img src='{{effect.icon}}' />
                 <label>{{effect.label}}</label>
                 <label>({{effect.remaining}})</label>
+                {{#if ../editable}}
                 <a data-action='wor-edit-effect' data-id='{{effect._id}}' title='Edit'>
                     <i class='fas fa-edit'></i>
                 </a>
                 <a data-action='wor-delete-effect' data-id='{{effect._id}}' title='Delete'>
                     <i class='fas fa-trash'></i>
                 </a>
+                {{/if}}
             </li>
             {{/each}}
         </ul>

--- a/src/effects/StatusEffect.ts
+++ b/src/effects/StatusEffect.ts
@@ -15,6 +15,11 @@ export default class StatusEffect extends ActiveEffect
         return UnknownExpiry
     }
 
+    override get name()
+    {
+        return this.data.label
+    }
+
     override get isTemporary(): boolean
     {
         // This flag determines whether an icon is displayed on the token. We

--- a/src/effects/StatusEffectConfig.hbs
+++ b/src/effects/StatusEffectConfig.hbs
@@ -1,50 +1,27 @@
-<form autocomplete='off'>
+<form class='wor {{cssClass}}' autocomplete='off'>
 
-    <header class='sheet-header'>
-        <img class='effect-icon' src='{{ data.icon }}' data-edit='icon'>
-        <h1 class='effect-title'>{{ data.label }}</h1>
+    <header class='wor-sheet-header'>
+        <img src='{{data.icon}}' data-edit='icon' />
+        <input type='text' name='label' value='{{data.label}}' placeholder='Name' />
     </header>
 
-    <section>
-        <div class='form-group'>
-            <label>Effect icon</label>
-            <div class='form-fields'>
-                {{filePicker target='icon' type='image'}}
-                <input class='image' type='text' name='icon' placeholder='path/image.png' value='{{data.icon}}' />
-            </div>
-        </div>
-
-        <div class='form-group'>
-            <label>Effect label</label>
-            <div class='form-fields'>
-                <input type='text' name='label' value='{{ data.label }}' />
-            </div>
-        </div>
-
-        <div class='form-group'>
-            <label>Started at</label>
-            <div class='form-fields'>
-                <input type='number' name='duration.startTime' value='{{ data.duration.startTime }}' />
-            </div>
-        </div>
-
-        <div class='form-group'>
-            <label>Started on initiative</label>
-            <div class='form-fields'>
-                <input type='number' step='0.01' name='flags.wor.initiative' value='{{ data.flags.wor.initiative }}' />
-            </div>
-        </div>
-
+    <section class='wor-section'>
         <div class='form-group'>
             <label>Duration</label>
-            <div class='form-fields'>
-                <input type='text' data-duration-editor='duration.seconds' />
-                <input type='number' readonly hidden name='duration.seconds' value='{{ data.duration.seconds }}' />
-            </div>
+            <input type='text' data-duration-editor='duration.seconds' />
+            <input type='number' readonly hidden name='duration.seconds' value='{{ data.duration.seconds }}' />
+        </div>
+        <div class='form-group'>
+            <label>Started at</label>
+            <input type='number' name='duration.startTime' value='{{ data.duration.startTime }}' />
+        </div>
+        <div class='form-group'>
+            <label>Started on initiative</label>
+            <input type='number' step='0.01' name='flags.wor.initiative' value='{{ data.flags.wor.initiative }}' />
         </div>
     </section>
 
     <footer class='sheet-footer'>
-        <button type='submit'><i class='fas fa-save'></i> {{localize submitText}}</button>
+        <button type='submit'><i class='fas fa-save'></i> Save</button>
     </footer>
 </form>

--- a/src/effects/StatusEffectConfig.ts
+++ b/src/effects/StatusEffectConfig.ts
@@ -1,3 +1,5 @@
+import { expect, unwrap } from '../helpers/assertions'
+import { requireElement } from '../helpers/require-element'
 import DurationEditors from './DurationEditors'
 import template from './StatusEffectConfig.hbs'
 
@@ -8,13 +10,55 @@ export default class StatusEffectConfig extends ActiveEffectConfig
     {
         return {
             ...super.defaultOptions,
-            template
+            classes: ['sheet'],
+            template,
+            width: 400,
         }
     }
 
-    override activateListeners(jQuery: JQuery): void
+    override get title(): string
     {
-        super.activateListeners(jQuery)
-        DurationEditors.initEditorsInForm(jQuery)
+        const actorName = unwrap(this.document.parent).name
+        const effectName = this.document.data.label
+        return `${effectName} on ${actorName}`
+    }
+
+    override activateListeners(html: JQuery): void
+    {
+        super.activateListeners(html)
+
+        // Add duration editor support:
+        DurationEditors.initEditorsInForm(html)
+
+        // Add image picker support:
+        if (this.isEditable)
+        {
+            html.find('img[data-edit]')[0].addEventListener('click', ev => this._onEditImage(ev))
+        }
+
+        // Initial focus:
+        if (this.document.data.label == 'New effect')
+        {
+            const initial = requireElement(html, 'label', HTMLInputElement)
+            initial.setSelectionRange(0, initial.value.length)
+            initial.focus()
+        }
+    }
+
+    _onEditImage(event: MouseEvent)
+    {
+        const img = event.currentTarget
+        expect(img instanceof HTMLImageElement)
+
+        const filePicker = new FilePicker({
+            type: 'image',
+            current: img.getAttribute('src') ?? undefined,
+            callback: path => img.src = path,
+            top: unwrap(this.position.top) + 40,
+            left: unwrap(this.position.left) + 10
+        })
+
+        // @ts-expect-error
+        return filePicker.browse()
     }
 }


### PR DESCRIPTION
This pull request makes the following changes:
* Simplify layout of status effect dialog.
* Hide add/edit buttons for readonly character sheets.
* Show confirm prompt when deleting unexpired effects.
* Use image picker in status effect dialog.

Note that the **duration** field is now the second field in the status effect dialog. This is to improve tabbing – since name and duration are usually the only fields we use.